### PR TITLE
[frontend] Revamped month view

### DIFF
--- a/frontend/src/components/MonthComponent.vue
+++ b/frontend/src/components/MonthComponent.vue
@@ -1,6 +1,18 @@
 <template>
 <div class="flex flex-col items-center p-2">
-  <router-link :to="'/year/'+props.year+'/month/'+props.month" class="font-bold text-3xl" :class="props.big ? 'lg:text-7xl' : '' " :textContent="StringUtils.capitalize(DateUtils.getMonth(props.month))+' '+props.year"/>
+  <router-link v-if="!big" :to="'/year/'+props.year+'/month/'+props.month" class="font-bold text-3xl" :class="props.big ? 'lg:text-7xl' : '' " :textContent="StringUtils.capitalize(DateUtils.getMonth(props.month))+' '+props.year"/>
+  <div class="flex flex-col items-center" v-else>
+    <router-link :to="'/year/'+props.year" class="font-bold text-3xl" :class="props.big ? 'lg:text-7xl' : '' " :textContent="props.year"/>
+    <div class="flex flex-row gap-14 items-end" :class="props.big ? 'lg:text-6xl' : '' ">
+      <router-link :to="previousMonthLink" >
+        <font-awesome-icon icon="fa-solid fa-arrow-left" />
+      </router-link>
+      <router-link :to="'/year/'+props.year+'/month/'+props.month" class="text-3xl" :class="props.big ? 'lg:text-7xl' : '' " :textContent="StringUtils.capitalize(DateUtils.getMonth(props.month))"/>
+      <router-link :to="followingMonthLink">
+        <font-awesome-icon icon="fa-solid fa-arrow-right" />
+      </router-link>
+    </div>
+  </div>
   <div class="grid grid-cols-7" :style="'grid-template-rows: repeat(' + DateUtils.getMonthWeeks(props.month, props.year) + ', minmax(0, 1fr));'">
     <span class="row-span-1 col-span-1 row-start-1 text-red-700 text-center" :class="props.big ? 'lg:text-6xl lg:m-10 text-xl' : 'text-xl' " :style="'grid-column-start: '+day+';'" v-for="day in 7" :textContent="DateUtils.getDayInitial(day)"/>
 
@@ -14,8 +26,9 @@
 import {StringUtils} from "@/libs/stringutils";
 import {DateUtils} from "@/libs/dateutils";
 import DayComponent from "@/components/DayComponent.vue";
-import {onBeforeMount} from "vue";
+import {computed, onBeforeMount} from "vue";
 import DetailedDayComponent from "@/components/DetailedDayComponent.vue";
+import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
 
 const props = defineProps<{
   month: number
@@ -24,6 +37,24 @@ const props = defineProps<{
 }>();
 
 let monthOffset : number;
+
+let previousMonthLink = computed(() => {
+  if(props.month==1) {
+    return "/year/"+(props.year-1)+"/month/12";
+  }
+
+  return "/year/"+props.year+"/month/"+(props.month-1);
+})
+
+let followingMonthLink = computed(() => {
+  if(props.month==12) {
+    return "/year/"+(props.year+1)+"/month/1";
+  }
+
+  return "/year/"+props.year+"/month/"+(props.month+1);
+
+})
+
 
 onBeforeMount(()=>{
   monthOffset = DateUtils.getMonthOffset(props.year, props.month)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,7 +9,7 @@ import {logoutUrl, ory, session} from "@/auth/auth";
 import "vue-toastification/dist/index.css"
 import type {PluginOptions} from "vue-toastification/dist/types/types";
 import VueToastificationPlugin, {POSITION} from "vue-toastification";
-import {faCheck, faMinus, faPlus, faXmark} from "@fortawesome/free-solid-svg-icons";
+import {faArrowLeft, faArrowRight, faCheck, faMinus, faPlus, faXmark} from "@fortawesome/free-solid-svg-icons";
 
 export const vercelEnv = import.meta.env.VITE_VERCEL_ENV
 const app = createApp(App)
@@ -21,7 +21,7 @@ const options : PluginOptions = {
     maxToasts: 20,
 }
 
-library.add(faCircleXmark, faXmark, faPlus, faMinus, faCheck)
+library.add(faCircleXmark, faXmark, faPlus, faMinus, faCheck, faArrowLeft, faArrowRight)
 
 
 app.use(router);


### PR DESCRIPTION
+ Revamped the month view's title so that it shows the month name and the year in different lines, for easier navigation between continuous months and to access the parent year view more easily (pending to find a good way to add the 12 months view into the equation), all while keeping the good ol' navbar that is kept synced thanks to the view store.